### PR TITLE
Currency API fixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,9 +16,9 @@ MoneyGoWhere is a financial planner to help you manage your finances.
 ### Adding an expense: `Add-Expense`
 Adds a new expense to the list of expenses.
 
-Syntax: `Add-Expense -n NAME -a AMOUNT [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]`
+Syntax: `Add-Expense -n NAME -a AMOUNT [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p MODE OF PAYMENT]`
 
-* `NAME`, `DESCRIPTION`, `CATEGORY` and `REMARKS` are text strings. You may use spaces within the text if you wrap the text with double quotes.
+* `NAME`, `DESCRIPTION`, `CATEGORY`, `REMARKS` and `MODE OF PAYMENT` are text strings. You may use spaces within the text if you wrap the text with double quotes.
 * `CURRENCY` is a text string. By default, it will be SGD. 
 * `AMOUNT` is a decimal value.
 * `DATE` is a text string in the format `"dd/MM/yyyy HHmm"`. If this value is not provided, MoneyGoWhere will save the current date and time for you.
@@ -31,6 +31,7 @@ Example of usage:
 * `Add-Expense -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses"`
 * `Add-Expense -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here"`
 * `Add-Expense -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here" -x USD`
+* `Add-Expense -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here" -x USD -p PayLah`
 
 ### Viewing expense(s): `View-Expense`
 Displays the past expenses you have added.
@@ -58,11 +59,10 @@ Example of usage:
 ### Editing an expense: `Edit-Expense`
 Edits an existing expense in the list of expenses.
 
-Syntax: `Edit-Expense -e EXPENSE_NUMBER [-n NAME] [-a AMOUNT] [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]`
+Syntax: `Edit-Expense -e EXPENSE_NUMBER [-n NAME] [-a AMOUNT] [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p MODE OF PAYMENT]`
 
 * `EXPENSE_NUMBER` is an integer value.
-* `NAME`, `DESCRIPTION`, `CATEGORY` and `REMARKS` are text strings. You may use spaces within the text if you wrap the text with double quotes.
-* `CURRENCY` is a text string. 
+* `NAME`, `DESCRIPTION`, `CATEGORY`, `REMARKS`, `CURRENCY` and `MODE OF PAYMENT` are text strings. You may use spaces within the text if you wrap the text with double quotes.
 * `AMOUNT` is a decimal value.
 * `DATE` is a text string in the format `"dd/MM/yyyy HHmm"`.
 
@@ -74,6 +74,7 @@ Example of usage:
 * `Edit-Expense -e 1 -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses"`
 * `Edit-Expense -e 1 -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here"`
 * `Edit-Expense -e 1 -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here" -x USD`
+* `Edit-Expense -e 1 -n "Cloud subscription" -a 13.37 -d "01/01/2022 2359" -t "Monthly payment" -c "Work expenses" -r "Remarks here" -x USD -p PayLah`
 
 ### Sorting expenses: `Sort-Expense`
 Sorts the list of expenses according to an alphabetical, amount, date or currency order. It can be sorted in both ascending and

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -19,7 +19,7 @@ Adds a new expense to the list of expenses.
 Syntax: `Add-Expense -n NAME -a AMOUNT [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p MODE OF PAYMENT]`
 
 * `NAME`, `DESCRIPTION`, `CATEGORY`, `REMARKS` and `MODE OF PAYMENT` are text strings. You may use spaces within the text if you wrap the text with double quotes.
-* `CURRENCY` is a text string. By default, it will be SGD. 
+* `CURRENCY` is a text string. By default, it will be SGD. Otherwise, it must be a valid currency code.
 * `AMOUNT` is a decimal value.
 * `DATE` is a text string in the format `"dd/MM/yyyy HHmm"`. If this value is not provided, MoneyGoWhere will save the current date and time for you.
 
@@ -62,7 +62,8 @@ Edits an existing expense in the list of expenses.
 Syntax: `Edit-Expense -e EXPENSE_NUMBER [-n NAME] [-a AMOUNT] [-d DATE] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p MODE OF PAYMENT]`
 
 * `EXPENSE_NUMBER` is an integer value.
-* `NAME`, `DESCRIPTION`, `CATEGORY`, `REMARKS`, `CURRENCY` and `MODE OF PAYMENT` are text strings. You may use spaces within the text if you wrap the text with double quotes.
+* `NAME`, `DESCRIPTION`, `CATEGORY`, `REMARKS` and `MODE OF PAYMENT` are text strings. You may use spaces within the text if you wrap the text with double quotes.
+* `CURRENCY` is a text string. It must be a valid currency code.
 * `AMOUNT` is a decimal value.
 * `DATE` is a text string in the format `"dd/MM/yyyy HHmm"`.
 
@@ -94,14 +95,15 @@ Example of usage:
 ### Converting currency of an expense: `Convert-Currency`
 Converts the currency of an expense from the list of expenses.
 
-Syntax: `Convert-Currency -e EXPENSE_NUMBER -x CURRENCY`
+Syntax: `Convert-Currency -e EXPENSE_NUMBER -x CURRENCY [-r RATE]`
 
 * `EXPENSE_NUMBER` is an integer value.
-* `CURRENCY` is a text string.
+* `CURRENCY` is a text string. It must be a valid currency code.
+* `RATE` is a decimal value. This rate should be the rate to convert the expense amount from the old currency to the new currency. 
 
 Example of usage:
 
-* `Convert-Currency -e 1 -x USD`
+* `Convert-Currency -e 1 -x USD -r 1.35`
 
 ### Adding recurring payments: `Add-RecurringPayment`
 Adds a recurring payment to the list of recurring payments

--- a/src/main/java/seedu/moneygowhere/commands/ConsoleCommandAddExpense.java
+++ b/src/main/java/seedu/moneygowhere/commands/ConsoleCommandAddExpense.java
@@ -15,6 +15,7 @@ public class ConsoleCommandAddExpense extends ConsoleCommand {
     private String category;
     private String remarks;
     private String currency;
+    private String modeOfPayment;
 
     public ConsoleCommandAddExpense(
             String name,
@@ -23,7 +24,8 @@ public class ConsoleCommandAddExpense extends ConsoleCommand {
             BigDecimal amount,
             String category,
             String remarks,
-            String currency
+            String currency,
+            String modeOfPayment
     ) {
         this.name = name;
         this.dateTime = dateTime;
@@ -32,6 +34,7 @@ public class ConsoleCommandAddExpense extends ConsoleCommand {
         this.category = category;
         this.remarks = remarks;
         this.currency = currency;
+        this.modeOfPayment = modeOfPayment;
     }
 
     public String getName() {
@@ -88,5 +91,13 @@ public class ConsoleCommandAddExpense extends ConsoleCommand {
 
     public void setCurrency(String currency) {
         this.currency = currency;
+    }
+
+    public String getModeOfPayment() {
+        return modeOfPayment;
+    }
+
+    public void setModeOfPayment(String modeOfPayment) {
+        this.modeOfPayment = modeOfPayment;
     }
 }

--- a/src/main/java/seedu/moneygowhere/commands/ConsoleCommandConvertCurrency.java
+++ b/src/main/java/seedu/moneygowhere/commands/ConsoleCommandConvertCurrency.java
@@ -12,10 +12,12 @@ import java.math.BigDecimal;
 public class ConsoleCommandConvertCurrency extends ConsoleCommand {
     private int expenseIndex;
     private String currency;
+    private BigDecimal rate;
 
-    public ConsoleCommandConvertCurrency(int expenseIndex, String currency) {
+    public ConsoleCommandConvertCurrency(int expenseIndex, String currency, BigDecimal rate) {
         this.expenseIndex = expenseIndex;
         this.currency = currency;
+        this.rate = rate;
     }
 
     public int getExpenseIndex() {
@@ -26,8 +28,17 @@ public class ConsoleCommandConvertCurrency extends ConsoleCommand {
         return currency;
     }
 
+    public BigDecimal getRate() {
+        return rate;
+    }
+
     public void changeCurrency(Expense expense, CurrencyManager currencyManager) {
-        BigDecimal newAmount = currencyManager.exchangeCurrency(expense, currency);
+        BigDecimal newAmount;
+        if (rate == null) {
+            newAmount = currencyManager.exchangeCurrency(expense, currency);
+        } else {
+            newAmount = currencyManager.exchangeCurrencyWithRate(expense, rate);
+        }
         expense.setAmount(newAmount);
         expense.setCurrency(currency);
     }

--- a/src/main/java/seedu/moneygowhere/commands/ConsoleCommandEditExpense.java
+++ b/src/main/java/seedu/moneygowhere/commands/ConsoleCommandEditExpense.java
@@ -15,8 +15,8 @@ public class ConsoleCommandEditExpense extends ConsoleCommand {
     private BigDecimal amount;
     private String category;
     private String remarks;
-
     private String currency;
+    private String modeOfPayment;
 
     public ConsoleCommandEditExpense(
             int expenseIndex,
@@ -26,7 +26,8 @@ public class ConsoleCommandEditExpense extends ConsoleCommand {
             BigDecimal amount,
             String category,
             String remarks,
-            String currency
+            String currency,
+            String modeOfPayment
     ) {
         this.expenseIndex = expenseIndex;
         this.name = name;
@@ -36,6 +37,7 @@ public class ConsoleCommandEditExpense extends ConsoleCommand {
         this.category = category;
         this.remarks = remarks;
         this.currency = currency;
+        this.modeOfPayment = modeOfPayment;
     }
 
     public int getExpenseIndex() {
@@ -100,5 +102,13 @@ public class ConsoleCommandEditExpense extends ConsoleCommand {
 
     public void setCurrency(String currency) {
         this.currency = currency;
+    }
+
+    public String getModeOfPayment() {
+        return modeOfPayment;
+    }
+
+    public void setModeOfPayment(String modeOfPayment) {
+        this.modeOfPayment = modeOfPayment;
     }
 }

--- a/src/main/java/seedu/moneygowhere/common/Messages.java
+++ b/src/main/java/seedu/moneygowhere/common/Messages.java
@@ -123,6 +123,10 @@ public class Messages {
             + ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_CURRENCY
             + " "
             + ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_CURRENCY_LONG.toUpperCase()
+            + "] [-"
+            + ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT
+            + " "
+            + ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
             + "]";
 
     public static final String CONSOLE_MESSAGE_COMMAND_ADD_EXPENSE_SUCCESS = ""
@@ -209,6 +213,10 @@ public class Messages {
             + ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_CURRENCY
             + " "
             + ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_CURRENCY_LONG.toUpperCase()
+            + "] [-"
+            + ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT
+            + " "
+            + ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
             + "]";
     public static final String CONSOLE_MESSAGE_COMMAND_EDIT_EXPENSE_SUCCESS = ""
             + "The expense was edited successfully.";

--- a/src/main/java/seedu/moneygowhere/common/Messages.java
+++ b/src/main/java/seedu/moneygowhere/common/Messages.java
@@ -86,6 +86,9 @@ public class Messages {
     /**
      * Defines messages for {@link seedu.moneygowhere.data.currency.CurrencyManager}.
      */
+    public static final String CURRENCY_MANAGER_RATES_NOT_FOUND = ""
+            + "There may be an error obtaining the updated Exchange Rate for your desired currency. " + '\n'
+            + "Please enter the exchange rate manually.";
     public static final String CURRENCY_MANAGER_CURRENCY_NOT_FOUND = ""
             + "Currency not found. Please try again.";
 
@@ -265,7 +268,12 @@ public class Messages {
             + " -"
             + ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY
             + " "
-            + ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG.toUpperCase();
+            + ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG.toUpperCase()
+            + " [-"
+            + ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_RATE
+            + " "
+            + ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG.toUpperCase()
+            + "]";
     public static final String CONSOLE_MESSAGE_COMMAND_CONVERT_CURRENCY_SUCCESS = ""
             + "The expense's currency was changed successfully.";
     public static final String CONSOLE_ERROR_COMMAND_CONVERT_CURRENCY_INVALID = ""

--- a/src/main/java/seedu/moneygowhere/data/currency/CurrencyManager.java
+++ b/src/main/java/seedu/moneygowhere/data/currency/CurrencyManager.java
@@ -31,10 +31,8 @@ public class CurrencyManager {
             return true;
         }
         if (exchangeRates.isEmpty()) {
-            System.out.println("no way");
             throw new CurrencyRatesNotFoundException(Messages.CURRENCY_MANAGER_RATES_NOT_FOUND);
         }
-        System.out.println("lolol");
         throw new CurrencyInvalidException(Messages.CURRENCY_MANAGER_CURRENCY_NOT_FOUND);
     }
 

--- a/src/main/java/seedu/moneygowhere/data/currency/CurrencyManager.java
+++ b/src/main/java/seedu/moneygowhere/data/currency/CurrencyManager.java
@@ -4,6 +4,7 @@ import seedu.moneygowhere.common.Configurations;
 import seedu.moneygowhere.common.Messages;
 import seedu.moneygowhere.data.expense.Expense;
 import seedu.moneygowhere.exceptions.CurrencyInvalidException;
+import seedu.moneygowhere.exceptions.CurrencyRatesNotFoundException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -25,10 +26,15 @@ public class CurrencyManager {
         exchangeRates.put(currencyCode, rate);
     }
 
-    public boolean hasCurrency(String currency) throws CurrencyInvalidException {
+    public boolean hasCurrency(String currency) throws CurrencyInvalidException, CurrencyRatesNotFoundException {
         if (exchangeRates.containsKey(currency)) {
             return true;
         }
+        if (exchangeRates.isEmpty()) {
+            System.out.println("no way");
+            throw new CurrencyRatesNotFoundException(Messages.CURRENCY_MANAGER_RATES_NOT_FOUND);
+        }
+        System.out.println("lolol");
         throw new CurrencyInvalidException(Messages.CURRENCY_MANAGER_CURRENCY_NOT_FOUND);
     }
 
@@ -56,6 +62,12 @@ public class CurrencyManager {
             return amountInSgd;
         }
         BigDecimal amountInNewCurrency = convertToNewCurrency(amountInSgd, newCurrency);
+        return amountInNewCurrency;
+    }
+
+    public BigDecimal exchangeCurrencyWithRate(Expense expense, BigDecimal rate) {
+        BigDecimal amount = expense.getAmount();
+        BigDecimal amountInNewCurrency = amount.multiply(rate);
         return amountInNewCurrency;
     }
 }

--- a/src/main/java/seedu/moneygowhere/data/expense/Expense.java
+++ b/src/main/java/seedu/moneygowhere/data/expense/Expense.java
@@ -15,6 +15,7 @@ public class Expense {
     private String category;
     private String remarks;
     private String currency;
+    private String modeOfPayment;
 
     public Expense(String name,
                    LocalDateTime dateTime,
@@ -22,7 +23,8 @@ public class Expense {
                    BigDecimal amount,
                    String category,
                    String remarks,
-                   String currency) {
+                   String currency,
+                   String modeOfPayment) {
         this.name = name;
         this.dateTime = dateTime;
         this.description = description;
@@ -30,6 +32,7 @@ public class Expense {
         this.category = category;
         this.remarks = remarks;
         this.currency = currency;
+        this.modeOfPayment = modeOfPayment;
     }
 
     public String getName() {
@@ -86,5 +89,13 @@ public class Expense {
 
     public void setCurrency(String currency) {
         this.currency = currency;
+    }
+
+    public String getModeOfPayment() {
+        return modeOfPayment;
+    }
+
+    public void setModeOfPayment(String modeOfPayment) {
+        this.modeOfPayment = modeOfPayment;
     }
 }

--- a/src/main/java/seedu/moneygowhere/exceptions/CurrencyRatesNotFoundException.java
+++ b/src/main/java/seedu/moneygowhere/exceptions/CurrencyRatesNotFoundException.java
@@ -1,0 +1,31 @@
+package seedu.moneygowhere.exceptions;
+
+/**
+ * Thrown when there are no rates to be found.
+ */
+@SuppressWarnings("unused")
+public class CurrencyRatesNotFoundException extends MoneyGoWhereException {
+    public CurrencyRatesNotFoundException() {
+    }
+
+    public CurrencyRatesNotFoundException(String message) {
+        super(message);
+    }
+
+    public CurrencyRatesNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CurrencyRatesNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public CurrencyRatesNotFoundException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace
+    ) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/seedu/moneygowhere/parser/ConsoleParser.java
+++ b/src/main/java/seedu/moneygowhere/parser/ConsoleParser.java
@@ -754,7 +754,9 @@ public class ConsoleParser {
         boolean hasAllCliOptions = options.hasLongOption(
                 ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_EXPENSE_INDEX_LONG)
                 && options.hasLongOption(
-                ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG);
+                ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG)
+                && options.hasLongOption(
+                ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG);
         assert hasAllCliOptions :
                 ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS;
     }
@@ -778,14 +780,20 @@ public class ConsoleParser {
         String currency = commandLine.getOptionValue(
                 ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG
         );
-
-        /* Checks if mandatory arguments are provided */
+        String rateStr = commandLine.getOptionValue(
+                ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG
+        );
 
         if (expenseIndexStr == null || currency == null) {
             throw new ConsoleParserCommandConvertCurrencyInvalidException();
         }
 
-
+        if (rateStr != null) {
+            BigDecimal rate = new BigDecimal(rateStr);
+            if (rate.compareTo(BigDecimal.ZERO) != 1) {
+                throw new ConsoleParserCommandConvertCurrencyInvalidException();
+            }
+        }
     }
 
     private static ConsoleCommandConvertCurrency parseCommandConvertCurrencyValues(CommandLine commandLine) {
@@ -795,13 +803,21 @@ public class ConsoleParser {
         String currency = commandLine.getOptionValue(
                 ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_LONG
         );
+        String rateStr = commandLine.getOptionValue(
+                ConsoleParserConfigurations.COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG
+        );
 
         int expenseIndex = Integer.parseInt(expenseIndexStr);
         currency = currency.toUpperCase();
+        BigDecimal rate = null;
+        if (rateStr != null) {
+            rate = new BigDecimal(rateStr);
+        }
 
         return new ConsoleCommandConvertCurrency(
                 expenseIndex,
-                currency
+                currency,
+                rate
         );
     }
 

--- a/src/main/java/seedu/moneygowhere/parser/ConsoleParser.java
+++ b/src/main/java/seedu/moneygowhere/parser/ConsoleParser.java
@@ -105,7 +105,9 @@ public class ConsoleParser {
                 && options.hasLongOption(
                 ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_REMARKS_LONG)
                 && options.hasLongOption(
-                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_CURRENCY_LONG);
+                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_CURRENCY_LONG)
+                && options.hasLongOption(
+                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_LONG);
 
         assert hasAllCliOptions :
                 ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS;
@@ -129,6 +131,22 @@ public class ConsoleParser {
         );
 
         if (name.isBlank()) {
+            throw new ConsoleParserCommandAddExpenseInvalidException();
+        }
+
+        String modeOfPayment = commandLine.getOptionValue(
+                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT
+        );
+
+        if (modeOfPayment != null
+                && !(modeOfPayment.equalsIgnoreCase(
+                        ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CASH)
+                        || modeOfPayment.equalsIgnoreCase(
+                                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYNOW)
+                        || modeOfPayment.equalsIgnoreCase(
+                                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYLAH)
+                        || modeOfPayment.equalsIgnoreCase(
+                                ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CARD))) {
             throw new ConsoleParserCommandAddExpenseInvalidException();
         }
     }
@@ -157,6 +175,9 @@ public class ConsoleParser {
             String currency = commandLine.getOptionValue(
                     ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_CURRENCY_LONG
             );
+            String modeOfPayment = commandLine.getOptionValue(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_LONG
+            );
 
             BigDecimal amount = new BigDecimal(amountStr);
 
@@ -181,7 +202,8 @@ public class ConsoleParser {
                     amount,
                     category,
                     remarks,
-                    currency
+                    currency,
+                    modeOfPayment
             );
         } catch (DateTimeParseException | NumberFormatException exception) {
             throw new ConsoleParserCommandAddExpenseInvalidException(exception);
@@ -196,6 +218,27 @@ public class ConsoleParser {
         String currencyNormalized = currency.toUpperCase();
 
         consoleCommandAddExpense.setCurrency(currencyNormalized);
+
+        String modeOfPayment = consoleCommandAddExpense.getModeOfPayment();
+
+        if (modeOfPayment != null) {
+            String modeOfPaymentNormalized = "";
+            if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CASH)) {
+                modeOfPaymentNormalized = "Cash";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYNOW)) {
+                modeOfPaymentNormalized = "PayNow";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYLAH)) {
+                modeOfPaymentNormalized = "PayLah";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CARD)) {
+                modeOfPaymentNormalized = "Card";
+            }
+            consoleCommandAddExpense.setModeOfPayment(modeOfPaymentNormalized);
+        }
+
 
         return consoleCommandAddExpense;
     }
@@ -426,7 +469,9 @@ public class ConsoleParser {
                 && options.hasLongOption(
                 ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_REMARKS_LONG)
                 && options.hasLongOption(
-                ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_CURRENCY_LONG);
+                ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_CURRENCY_LONG)
+                && options.hasLongOption(
+                ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_LONG);
 
         assert hasAllCliOptions :
                 ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS;
@@ -451,6 +496,9 @@ public class ConsoleParser {
         String expenseIndexStr = commandLine.getOptionValue(
                 ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_EXPENSE_INDEX_LONG
         );
+        String modeOfPayment = commandLine.getOptionValue(
+                ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_LONG
+        );
 
         if (name != null && name.isBlank()) {
             throw new ConsoleParserCommandEditExpenseInvalidException();
@@ -468,6 +516,18 @@ public class ConsoleParser {
             if (expenseIndex < 0) {
                 throw new ConsoleParserCommandEditExpenseInvalidException();
             }
+        }
+
+        if (modeOfPayment != null
+                && !(modeOfPayment.equalsIgnoreCase(
+                        ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CASH)
+                        || modeOfPayment.equalsIgnoreCase(
+                        ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYNOW)
+                        || modeOfPayment.equalsIgnoreCase(
+                        ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYLAH)
+                        || modeOfPayment.equalsIgnoreCase(
+                        ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CARD))) {
+            throw new ConsoleParserCommandEditExpenseInvalidException();
         }
     }
 
@@ -498,6 +558,9 @@ public class ConsoleParser {
             String currency = commandLine.getOptionValue(
                     ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_CURRENCY_LONG
             );
+            String modeOfPayment = commandLine.getOptionValue(
+                    ConsoleParserConfigurations.COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_LONG
+            );
 
             int expenseIndex = Integer.parseInt(expenseIndexStr);
 
@@ -526,7 +589,8 @@ public class ConsoleParser {
                     amount,
                     category,
                     remarks,
-                    currency
+                    currency,
+                    modeOfPayment
             );
         } catch (DateTimeParseException | NumberFormatException exception) {
             throw new ConsoleParserCommandEditExpenseInvalidException(exception);
@@ -536,6 +600,26 @@ public class ConsoleParser {
     private static ConsoleCommandEditExpense normalizeCommandEditExpenseValues(
             ConsoleCommandEditExpense consoleCommandEditExpense
     ) {
+
+        String modeOfPayment = consoleCommandEditExpense.getModeOfPayment();
+
+        if (modeOfPayment != null) {
+            String modeOfPaymentNormalized = "";
+            if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CASH)) {
+                modeOfPaymentNormalized = "Cash";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYNOW)) {
+                modeOfPaymentNormalized = "PayNow";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYLAH)) {
+                modeOfPaymentNormalized = "PayLah";
+            } else if (modeOfPayment.equalsIgnoreCase(
+                    ConsoleParserConfigurations.COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CARD)) {
+                modeOfPaymentNormalized = "Card";
+            }
+            consoleCommandEditExpense.setModeOfPayment(modeOfPaymentNormalized);
+        }
         return consoleCommandEditExpense;
     }
 

--- a/src/main/java/seedu/moneygowhere/parser/ConsoleParserConfigurations.java
+++ b/src/main/java/seedu/moneygowhere/parser/ConsoleParserConfigurations.java
@@ -51,6 +51,17 @@ public class ConsoleParserConfigurations {
     public static final String COMMAND_ADD_EXPENSE_ARG_CURRENCY_DESC = "currency";
     public static final boolean COMMAND_ADD_EXPENSE_ARG_CURRENCY_HAS_VAL = true;
     public static final boolean COMMAND_ADD_EXPENSE_ARG_CURRENCY_IS_MAND = false;
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT = "p";
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_LONG = "mode of payment";
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_DESC = ""
+            + "PayLah/PayNow/Cash/Card";
+    public static final boolean COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL = true;
+    public static final boolean COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND = false;
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYLAH = "PayLah";
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_PAYNOW = "PayNow";
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CASH = "Cash";
+    public static final String COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_CARD = "Card";
+
     public static final String COMMAND_ADD_EXPENSE_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS = ""
             + "Command Add-Expense does not have all of the required options.";
 
@@ -127,6 +138,12 @@ public class ConsoleParserConfigurations {
     public static final String COMMAND_EDIT_EXPENSE_ARG_CURRENCY_DESC = "currency";
     public static final boolean COMMAND_EDIT_EXPENSE_ARG_CURRENCY_HAS_VAL = true;
     public static final boolean COMMAND_EDIT_EXPENSE_ARG_CURRENCY_IS_MAND = false;
+    public static final String COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT = "p";
+    public static final String COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_LONG = "mode of payment";
+    public static final String COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_DESC = ""
+            + "PayLah/PayNow/Cash/Card";
+    public static final boolean COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL = true;
+    public static final boolean COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND = false;
     public static final String COMMAND_EDIT_EXPENSE_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS = ""
             + "Command Edit-Expense does not have all of the required options.";
 
@@ -140,18 +157,18 @@ public class ConsoleParserConfigurations {
             + "Alphabetical/Amount/Date";
     public static final boolean COMMAND_SORT_EXPENSE_ARG_TYPE_HAS_VAL = true;
     public static final boolean COMMAND_SORT_EXPENSE_ARG_TYPE_IS_MAND = true;
-    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_ALPHABETICAL = "alphabetical";
-    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_AMOUNT = "amount";
-    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_DATE = "date";
-    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_CURRENCY = "currency";
+    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_ALPHABETICAL = "Alphabetical";
+    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_AMOUNT = "Amount";
+    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_DATE = "Date";
+    public static final String COMMAND_SORT_EXPENSE_ARG_TYPE_VAL_CURRENCY = "Currency";
     public static final String COMMAND_SORT_EXPENSE_ARG_ORDER = "o";
     public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_LONG = "order";
     public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_DESC = ""
             + "Ascending/Descending";
     public static final boolean COMMAND_SORT_EXPENSE_ARG_ORDER_HAS_VAL = true;
     public static final boolean COMMAND_SORT_EXPENSE_ARG_ORDER_IS_MAND = true;
-    public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_VAL_ASCENDING = "ascending";
-    public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_VAL_DESCENDING = "descending";
+    public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_VAL_ASCENDING = "Ascending";
+    public static final String COMMAND_SORT_EXPENSE_ARG_ORDER_VAL_DESCENDING = "Descending";
     public static final String COMMAND_SORT_EXPENSE_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS = ""
             + "Command Sort-Expense does not have all of the required options.";
 
@@ -484,8 +501,16 @@ public class ConsoleParserConfigurations {
                 COMMAND_ADD_EXPENSE_ARG_CURRENCY_DESC
         );
         optionCurrency.setRequired(COMMAND_ADD_EXPENSE_ARG_CURRENCY_IS_MAND);
+        Option optionModeOfPayment = new Option(
+                COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT,
+                COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_LONG,
+                COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL,
+                COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
+        );
+        optionCurrency.setRequired(COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
 
         Options options = new Options();
+        options.addOption(optionModeOfPayment);
         options.addOption(optionName);
         options.addOption(optionAmount);
         options.addOption(optionDateTime);
@@ -607,8 +632,16 @@ public class ConsoleParserConfigurations {
                 COMMAND_EDIT_EXPENSE_ARG_CURRENCY_DESC
         );
         optionCurrency.setRequired(COMMAND_EDIT_EXPENSE_ARG_CURRENCY_IS_MAND);
+        Option optionModeOfPayment = new Option(
+                COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT,
+                COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_LONG,
+                COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL,
+                COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
+        );
+        optionCurrency.setRequired(COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
 
         Options options = new Options();
+        options.addOption(optionModeOfPayment);
         options.addOption(optionExpenseIndex);
         options.addOption(optionName);
         options.addOption(optionDateTime);

--- a/src/main/java/seedu/moneygowhere/parser/ConsoleParserConfigurations.java
+++ b/src/main/java/seedu/moneygowhere/parser/ConsoleParserConfigurations.java
@@ -186,6 +186,11 @@ public class ConsoleParserConfigurations {
     public static final String COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_DESC = "currency";
     public static final boolean COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_HAS_VAL = true;
     public static final boolean COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_IS_MAND = true;
+    public static final String COMMAND_CONVERT_CURRENCY_ARG_RATE = "r";
+    public static final String COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG = "rate";
+    public static final String COMMAND_CONVERT_CURRENCY_ARG_RATE_DESC = "rate";
+    public static final boolean COMMAND_CONVERT_CURRENCY_ARG_RATE_HAS_VAL = true;
+    public static final boolean COMMAND_CONVERT_CURRENCY_ARG_RATE_IS_MAND = false;
     public static final String COMMAND_CONVERT_CURRENCY_ASSERT_FAILURE_MESSAGE_ALL_CLI_OPTIONS = ""
             + "Command Convert-Currency does not have all of the required options.";
 
@@ -527,10 +532,9 @@ public class ConsoleParserConfigurations {
                 COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL,
                 COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
         );
-        optionCurrency.setRequired(COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
+        optionModeOfPayment.setRequired(COMMAND_ADD_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
 
         Options options = new Options();
-        options.addOption(optionModeOfPayment);
         options.addOption(optionName);
         options.addOption(optionAmount);
         options.addOption(optionDateTime);
@@ -538,6 +542,7 @@ public class ConsoleParserConfigurations {
         options.addOption(optionCategory);
         options.addOption(optionRemarks);
         options.addOption(optionCurrency);
+        options.addOption(optionModeOfPayment);
 
         return options;
     }
@@ -658,10 +663,9 @@ public class ConsoleParserConfigurations {
                 COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_HAS_VAL,
                 COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_DESC
         );
-        optionCurrency.setRequired(COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
+        optionModeOfPayment.setRequired(COMMAND_EDIT_EXPENSE_ARG_MODE_OF_PAYMENT_IS_MAND);
 
         Options options = new Options();
-        options.addOption(optionModeOfPayment);
         options.addOption(optionExpenseIndex);
         options.addOption(optionName);
         options.addOption(optionDateTime);
@@ -670,6 +674,7 @@ public class ConsoleParserConfigurations {
         options.addOption(optionCategory);
         options.addOption(optionRemarks);
         options.addOption(optionCurrency);
+        options.addOption(optionModeOfPayment);
 
         return options;
     }
@@ -722,10 +727,18 @@ public class ConsoleParserConfigurations {
                 COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_DESC
         );
         optionCurrency.setRequired(COMMAND_CONVERT_CURRENCY_ARG_CURRENCY_IS_MAND);
+        Option optionRate = new Option(
+                COMMAND_CONVERT_CURRENCY_ARG_RATE,
+                COMMAND_CONVERT_CURRENCY_ARG_RATE_LONG,
+                COMMAND_CONVERT_CURRENCY_ARG_RATE_HAS_VAL,
+                COMMAND_CONVERT_CURRENCY_ARG_RATE_DESC
+        );
+        optionRate.setRequired(COMMAND_CONVERT_CURRENCY_ARG_RATE_IS_MAND);
 
         Options options = new Options();
         options.addOption(optionExpenseIndex);
         options.addOption(optionCurrency);
+        options.addOption(optionRate);
 
         return options;
     }

--- a/src/main/java/seedu/moneygowhere/storage/LocalStorage.java
+++ b/src/main/java/seedu/moneygowhere/storage/LocalStorage.java
@@ -41,6 +41,7 @@ import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_DESCRIPTION_ELEMENT;
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_ELEMENT;
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_ID_ATTRIBUTE;
+import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_MODE_OF_PAYMENT_ELEMENT;
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_NAME_ELEMENT;
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_EXPENSE_REMARKS_ELEMENT;
 import static seedu.moneygowhere.storage.LocalStorageConfigurations.XML_INCOME_AMOUNT_ELEMENT;
@@ -209,7 +210,9 @@ public class LocalStorage {
                 .item(0).getTextContent();
         String remark = element.getElementsByTagName(XML_EXPENSE_REMARKS_ELEMENT)
                 .item(0).getTextContent();
-        return new Expense(name, dateTime, description, amount, category, remark, currency);
+        String modeOfPayment = element.getElementsByTagName(XML_EXPENSE_MODE_OF_PAYMENT_ELEMENT)
+                .item(0).getTextContent();
+        return new Expense(name, dateTime, description, amount, category, remark, currency, modeOfPayment);
     }
 
     /**
@@ -340,6 +343,9 @@ public class LocalStorage {
             Element remark = doc.createElement(XML_EXPENSE_REMARKS_ELEMENT);
             remark.setTextContent(expense.getRemarks());
             expenseElement.appendChild(remark);
+            Element modeOfPayment = doc.createElement(XML_EXPENSE_MODE_OF_PAYMENT_ELEMENT);
+            remark.setTextContent(expense.getModeOfPayment());
+            expenseElement.appendChild(modeOfPayment);
             index++;
         }
     }

--- a/src/main/java/seedu/moneygowhere/storage/LocalStorageConfigurations.java
+++ b/src/main/java/seedu/moneygowhere/storage/LocalStorageConfigurations.java
@@ -15,6 +15,7 @@ public class LocalStorageConfigurations {
     public static final String XML_EXPENSE_AMOUNT_CURRENCY_ATTRIBUTE = "Currency";
     public static final String XML_EXPENSE_CATEGORY_ELEMENT = "Category";
     public static final String XML_EXPENSE_REMARKS_ELEMENT = "Remark";
+    public static final String XML_EXPENSE_MODE_OF_PAYMENT_ELEMENT = "Mode_Of_Payment";
     public static final String XML_TARGET_ELEMENT = "Target";
     public static final String XML_TARGET_ID_ATTRIBUTE = "Id";
     public static final String XML_TARGET_NAME_ELEMENT = "Name";

--- a/src/main/java/seedu/moneygowhere/userinterface/ConsoleInterface.java
+++ b/src/main/java/seedu/moneygowhere/userinterface/ConsoleInterface.java
@@ -188,13 +188,14 @@ public class ConsoleInterface {
         );
 
         String expenseStr = "";
-        expenseStr += "Name          : " + expense.getName() + "\n";
-        expenseStr += "Date and Time : " + expense.getDateTime().format(dateTimeFormat) + "\n";
-        expenseStr += "Description   : " + expense.getDescription() + "\n";
-        expenseStr += "Amount        : " + expense.getAmount() + "\n";
-        expenseStr += "Category      : " + expense.getCategory() + "\n";
-        expenseStr += "Remarks       : " + expense.getRemarks() + "\n";
-        expenseStr += "Currency      : " + expense.getCurrency();
+        expenseStr += "Name            : " + expense.getName() + "\n";
+        expenseStr += "Date and Time   : " + expense.getDateTime().format(dateTimeFormat) + "\n";
+        expenseStr += "Description     : " + expense.getDescription() + "\n";
+        expenseStr += "Amount          : " + expense.getAmount() + "\n";
+        expenseStr += "Category        : " + expense.getCategory() + "\n";
+        expenseStr += "Remarks         : " + expense.getRemarks() + "\n";
+        expenseStr += "Currency        : " + expense.getCurrency() + "\n";
+        expenseStr += "Mode of Payment : " + expense.getModeOfPayment();
 
         return expenseStr;
     }
@@ -277,7 +278,8 @@ public class ConsoleInterface {
                 consoleCommandAddExpense.getAmount(),
                 consoleCommandAddExpense.getCategory(),
                 consoleCommandAddExpense.getRemarks(),
-                consoleCommandAddExpense.getCurrency());
+                consoleCommandAddExpense.getCurrency(),
+                consoleCommandAddExpense.getModeOfPayment());
         expenseManager.addExpense(expense);
 
         printInformationalMessage(convertExpenseToConsoleString(expense));
@@ -403,8 +405,21 @@ public class ConsoleInterface {
             }
         }
         currency = currency.toUpperCase();
+        String modeOfPayment = consoleCommandEditExpense.getModeOfPayment();
+        if (modeOfPayment == null) {
+            modeOfPayment = oldExpense.getModeOfPayment();
+        }
 
-        Expense newExpense = new Expense(name, dateTime, description, amount, category, remarks, currency);
+        Expense newExpense = new Expense(
+                name,
+                dateTime,
+                description,
+                amount,
+                category,
+                remarks,
+                currency,
+                modeOfPayment
+        );
         try {
             expenseManager.editExpense(expenseIndex, newExpense);
         } catch (ExpenseManagerExpenseNotFoundException exception) {

--- a/src/main/java/seedu/moneygowhere/userinterface/ConsoleInterface.java
+++ b/src/main/java/seedu/moneygowhere/userinterface/ConsoleInterface.java
@@ -48,6 +48,7 @@ import seedu.moneygowhere.exceptions.ConsoleParserCommandViewExpenseInvalidExcep
 import seedu.moneygowhere.exceptions.ConsoleParserCommandViewRecurringPaymentInvalidException;
 import seedu.moneygowhere.exceptions.ConsoleParserCommandViewTargetInvalidException;
 import seedu.moneygowhere.exceptions.CurrencyInvalidException;
+import seedu.moneygowhere.exceptions.CurrencyRatesNotFoundException;
 import seedu.moneygowhere.exceptions.ExpenseManagerExpenseNotFoundException;
 import seedu.moneygowhere.exceptions.RecurringPaymentManagerRecurringPaymentNotFoundException;
 import seedu.moneygowhere.exceptions.TargetManagerTargetNotFoundException;
@@ -268,7 +269,8 @@ public class ConsoleInterface {
     private void runCommandAddExpense(ConsoleCommandAddExpense consoleCommandAddExpense) {
         try {
             currencyManager.hasCurrency(consoleCommandAddExpense.getCurrency());
-        } catch (CurrencyInvalidException exception) {
+        } catch (CurrencyInvalidException
+                 | CurrencyRatesNotFoundException exception) {
             printErrorMessage(exception.getMessage());
             return;
         }
@@ -401,7 +403,8 @@ public class ConsoleInterface {
         } else {
             try {
                 currencyManager.hasCurrency(consoleCommandEditExpense.getCurrency());
-            } catch (CurrencyInvalidException exception) {
+            } catch (CurrencyInvalidException
+                     | CurrencyRatesNotFoundException exception) {
                 printErrorMessage(exception.getMessage());
                 return;
             }
@@ -455,11 +458,15 @@ public class ConsoleInterface {
             return;
         }
 
-        try {
-            currencyManager.hasCurrency(consoleCommandConvertCurrency.getCurrency());
-        } catch (CurrencyInvalidException exception) {
-            printErrorMessage(exception.getMessage());
-            return;
+        BigDecimal rate = consoleCommandConvertCurrency.getRate();
+        if (rate == null) {
+            try {
+                currencyManager.hasCurrency(consoleCommandConvertCurrency.getCurrency());
+            } catch (CurrencyInvalidException
+                     | CurrencyRatesNotFoundException exception) {
+                printErrorMessage(exception.getMessage());
+                return;
+            }
         }
 
         consoleCommandConvertCurrency.changeCurrency(expense, currencyManager);

--- a/src/test/java/seedu/moneygowhere/parser/ConsoleParserTest.java
+++ b/src/test/java/seedu/moneygowhere/parser/ConsoleParserTest.java
@@ -109,13 +109,17 @@ class ConsoleParserTest {
         boolean isCategoryEqual = consoleCommandAddExpense
                 .getCategory()
                 == null;
+        boolean isModeOfPaymentEqual = consoleCommandAddExpense
+                .getModeOfPayment()
+                == null;
 
         assertTrue(
                 isNameEqual
                         && isDateTimeEqual
                         && isDescriptionEqual
                         && isAmountEqual
-                        && isCategoryEqual);
+                        && isCategoryEqual
+                        && isModeOfPaymentEqual);
     }
 
     @Test

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -8,427 +8,1009 @@
                           |___/                                            
 
 Your MoneyGoWhere? Let me help you find it.
-There is no load file found...
-Please ensure the file is named correctly and is in the right directory if you have a load file.
+File loaded successfully :)
 Currencies loaded successfully :)
 
 
 ERROR: The command entered is invalid.
 
 
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-Name          : Test Expense 3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-Name          : Test Expense 4
-Date and Time : 03 Jan 2022 12:03
-Description   : This is a test expense 4
-Amount        : 30.90
-Category      : Category Alpha
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 
 The expense was added successfully.
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 4
-Date and Time : 03 Jan 2022 12:03
-Description   : This is a test expense 4
-Amount        : 30.90
-Category      : Category Alpha
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 5 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 10 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 11 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 15 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 4
-Date and Time : 03 Jan 2022 12:03
-Description   : This is a test expense 4
-Amount        : 30.90
-Category      : Category Alpha
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 5 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 10 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 11 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 15 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 ERROR: The expense is not found.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 4
-Date and Time : 03 Jan 2022 12:03
-Description   : This is a test expense 4
-Amount        : 30.90
-Category      : Category Alpha
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 5 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 10 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 11 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 15 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 The expense was deleted successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 1
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 1337.37
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 5 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 10 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 11 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 ---- EXPENSE INDEX 2 ----
-Name          : Exp3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Exp3
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 
 The expense was edited successfully.
 
 
 ---- EXPENSE INDEX 1 ----
-Name          : Exp2
-Date and Time : 01 Jan 2022 12:00
-Description   : null
-Amount        : 10.70
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Exp2
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 10.70
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 
 The expense was edited successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Exp1
-Date and Time : 01 Jan 2021 12:00
-Description   : This is a test expense 1
-Amount        : 13.37
-Category      : Category Alpha
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
 
 The expense was edited successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Exp1
-Date and Time : 01 Jan 2021 12:00
-Description   : This is a test expense 1
-Amount        : 13.37
-Category      : Category Alpha
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Exp2
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 10.70
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Exp3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Exp3
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 5 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 10 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 11 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY]
+ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
 
 
 ERROR: The expense is not found.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Exp1
-Date and Time : 01 Jan 2021 12:00
-Description   : This is a test expense 1
-Amount        : 13.37
-Category      : Category Alpha
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Exp2
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 10.70
+Category        : Category Bravo
+Remarks         : Remarks Alpha
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name          : Exp3
-Date and Time : 02 Jan 2022 12:02
-Description   : This is a test expense 3
-Amount        : 20.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Exp3
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 2 ----
-Name          : Test Expense 2
-Date and Time : 01 Jan 2022 12:01
-Description   : null
-Amount        : 10.80
-Category      : null
-Remarks       : null
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 3 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 4 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 5 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 7 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 8 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 10 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 11 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 12 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 13 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 14 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 The expense was deleted successfully.
@@ -441,21 +1023,113 @@ The expense was deleted successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name          : Test Expense 5
-Date and Time : 04 Jan 2022 12:04
-Description   : This is a test expense 5
-Amount        : 40.90
-Category      : Category Bravo
-Remarks       : Remarks Alpha
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     :
+Amount          : 10.80
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 ---- EXPENSE INDEX 1 ----
-Name          : Test Expense 6
-Date and Time : 04 Jan 2022 12:05
-Description   : This is a test expense 6
-Amount        : 50.90
-Category      : Category Charlie
-Remarks       : Remarks Bravo
-Currency      : SGD
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 4 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 5 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     :
+Amount          : 1337.37
+Category        :
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 6 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 7 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 8 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 9 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 10 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
+---- EXPENSE INDEX 11 ----
+Name            : Exp1
+Date and Time   : 01 Jan 2021 12:00
+Description     : This is a test expense 1
+Amount          : 13.37
+Category        : Category Alpha
+Remarks         :
+Currency        : SGD
+Mode of Payment :
 
 
 ERROR: The command entered is invalid.
@@ -582,16 +1256,16 @@ Your expenses have been sorted successfully.
 Your expenses have been sorted successfully.
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t alphabetical/amount/date/currency -o ascending/descending
+ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t Alphabetical/Amount/Date/Currency -o Ascending/Descending
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t alphabetical/amount/date/currency -o ascending/descending
+ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t Alphabetical/Amount/Date/Currency -o Ascending/Descending
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t alphabetical/amount/date/currency -o ascending/descending
+ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t Alphabetical/Amount/Date/Currency -o Ascending/Descending
 
 
-ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t alphabetical/amount/date/currency -o ascending/descending
+ERROR: The arguments entered are invalid. SYNTAX: Sort-Expense -t Alphabetical/Amount/Date/Currency -o Ascending/Descending
 
 
 ERROR: The command entered is invalid.

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -8,7 +8,8 @@
                           |___/                                            
 
 Your MoneyGoWhere? Let me help you find it.
-File loaded successfully :)
+There is no load file found...
+Please ensure the file is named correctly and is in the right directory if you have a load file.
 Currencies loaded successfully :)
 
 
@@ -97,33 +98,24 @@ ERROR: The arguments entered are invalid. SYNTAX: Add-Expense -n NAME -a AMOUNT 
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Test Expense 6
-Date and Time   : 04 Jan 2022 12:05
-Description     : This is a test expense 6
-Amount          : 50.90
-Category        : Category Charlie
-Remarks         : Remarks Bravo
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Test Expense 5
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 40.90
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 4
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 3 ----
+---- EXPENSE INDEX 1 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
 Name            : Test Expense 3
 Date and Time   : 02 Jan 2022 12:02
 Description     : This is a test expense 3
@@ -132,117 +124,25 @@ Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 ---- EXPENSE INDEX 5 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 10 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 11 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 15 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
-
-
----- EXPENSE INDEX 0 ----
 Name            : Test Expense 6
 Date and Time   : 04 Jan 2022 12:05
 Description     : This is a test expense 6
@@ -254,33 +154,35 @@ Mode of Payment : null
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Test Expense 6
-Date and Time   : 04 Jan 2022 12:05
-Description     : This is a test expense 6
-Amount          : 50.90
-Category        : Category Charlie
-Remarks         : Remarks Bravo
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Test Expense 5
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 40.90
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 4
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 3 ----
+
+
+---- EXPENSE INDEX 0 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 1 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
 Name            : Test Expense 3
 Date and Time   : 02 Jan 2022 12:02
 Description     : This is a test expense 3
@@ -289,147 +191,57 @@ Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 4
+Date and Time   : 03 Jan 2022 12:03
+Description     : This is a test expense 4
+Amount          : 30.90
+Category        : Category Alpha
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
 ---- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 ---- EXPENSE INDEX 5 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 10 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 11 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 15 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
 
 
 ERROR: The expense is not found.
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Test Expense 6
-Date and Time   : 04 Jan 2022 12:05
-Description     : This is a test expense 6
-Amount          : 50.90
-Category        : Category Charlie
-Remarks         : Remarks Bravo
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Test Expense 5
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 40.90
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 4
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 3 ----
+---- EXPENSE INDEX 1 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
 Name            : Test Expense 3
 Date and Time   : 02 Jan 2022 12:02
 Description     : This is a test expense 3
@@ -438,138 +250,7 @@ Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 5 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 10 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 11 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 15 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
-
-
-The expense was deleted successfully.
-
-
----- EXPENSE INDEX 0 ----
-Name            : Test Expense 6
-Date and Time   : 04 Jan 2022 12:05
-Description     : This is a test expense 6
-Amount          : 50.90
-Category        : Category Charlie
-Remarks         : Remarks Bravo
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Test Expense 5
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 40.90
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
+---- EXPENSE INDEX 3 ----
 Name            : Test Expense 4
 Date and Time   : 03 Jan 2022 12:03
 Description     : This is a test expense 4
@@ -578,25 +259,39 @@ Category        : Category Alpha
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 3 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
 ---- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 ---- EXPENSE INDEX 5 ----
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
+Currency        : SGD
+Mode of Payment : null
+
+
+The expense was deleted successfully.
+
+
+---- EXPENSE INDEX 0 ----
+Name            : Test Expense 1
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
+Amount          : 1337.37
+Category        : null
+Remarks         : null
+Currency        : SGD
+Mode of Payment : null
+---- EXPENSE INDEX 1 ----
 Name            : Test Expense 2
 Date and Time   : 01 Jan 2022 12:01
 Description     : null
@@ -605,95 +300,41 @@ Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 10 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
+---- EXPENSE INDEX 2 ----
+Name            : Test Expense 3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
 Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 11 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 4 ----
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 
 
 ---- EXPENSE INDEX 2 ----
 Name            : Exp3
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
 Remarks         : null
 Currency        : SGD
 Mode of Payment : null
@@ -703,11 +344,11 @@ The expense was edited successfully.
 
 ---- EXPENSE INDEX 1 ----
 Name            : Exp2
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
+Date and Time   : 01 Jan 2022 12:00
+Description     : null
 Amount          : 10.70
-Category        : Category Bravo
-Remarks         : Remarks Alpha
+Category        : null
+Remarks         : null
 Currency        : SGD
 Mode of Payment : null
 
@@ -728,96 +369,6 @@ The expense was edited successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Exp2
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 10.70
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Exp3
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 3 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 5 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 10 ----
 Name            : Exp1
 Date and Time   : 01 Jan 2021 12:00
 Description     : This is a test expense 1
@@ -826,42 +377,42 @@ Category        : Category Alpha
 Remarks         : Remarks Bravo
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 11 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+---- EXPENSE INDEX 1 ----
+Name            : Exp3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 4 ----
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 
 
 ERROR: The arguments entered are invalid. SYNTAX: Edit-Expense -e EXPENSE-INDEX [-n NAME] [-d dd/MM/yyyy HHmm] [-t DESCRIPTION] [-a AMOUNT] [-c CATEGORY] [-r REMARKS] [-x CURRENCY] [-p PayLah/PayNow/Cash/Card]
@@ -877,96 +428,6 @@ ERROR: The expense is not found.
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Exp2
-Date and Time   : 04 Jan 2022 12:04
-Description     : This is a test expense 5
-Amount          : 10.70
-Category        : Category Bravo
-Remarks         : Remarks Alpha
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 1 ----
-Name            : Exp3
-Date and Time   : 03 Jan 2022 12:03
-Description     : This is a test expense 4
-Amount          : 30.90
-Category        : Category Alpha
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 3 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 4 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 5 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 7 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 8 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 10 ----
 Name            : Exp1
 Date and Time   : 01 Jan 2021 12:00
 Description     : This is a test expense 1
@@ -975,42 +436,42 @@ Category        : Category Alpha
 Remarks         : Remarks Bravo
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 11 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+---- EXPENSE INDEX 1 ----
+Name            : Exp3
+Date and Time   : 02 Jan 2022 12:02
+Description     : This is a test expense 3
+Amount          : 20.80
+Category        : null
+Remarks         : null
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 12 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 2 ----
+Name            : Test Expense 2
+Date and Time   : 01 Jan 2022 12:01
+Description     : null
+Amount          : 10.80
+Category        : null
+Remarks         : null
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 13 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 3 ----
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 14 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
+Mode of Payment : null
+---- EXPENSE INDEX 4 ----
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
+Remarks         : Remarks Bravo
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 
 
 The expense was deleted successfully.
@@ -1023,113 +484,23 @@ The expense was deleted successfully.
 
 
 ---- EXPENSE INDEX 0 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     :
-Amount          : 10.80
-Category        :
-Remarks         :
+Name            : Test Expense 5
+Date and Time   : 04 Jan 2022 12:04
+Description     : This is a test expense 5
+Amount          : 40.90
+Category        : Category Bravo
+Remarks         : Remarks Alpha
 Currency        : SGD
-Mode of Payment :
+Mode of Payment : null
 ---- EXPENSE INDEX 1 ----
-Name            : Test Expense 2
-Date and Time   : 01 Jan 2022 12:01
-Description     : null
-Amount          : 10.80
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 2 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 3 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 4 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 5 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     :
-Amount          : 1337.37
-Category        :
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 6 ----
-Name            : Test Expense 1
-Date and Time   : 01 Jan 2022 12:00
-Description     : null
-Amount          : 1337.37
-Category        : null
-Remarks         : null
-Currency        : SGD
-Mode of Payment : null
----- EXPENSE INDEX 7 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
+Name            : Test Expense 6
+Date and Time   : 04 Jan 2022 12:05
+Description     : This is a test expense 6
+Amount          : 50.90
+Category        : Category Charlie
 Remarks         : Remarks Bravo
 Currency        : SGD
 Mode of Payment : null
----- EXPENSE INDEX 8 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 9 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 10 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
----- EXPENSE INDEX 11 ----
-Name            : Exp1
-Date and Time   : 01 Jan 2021 12:00
-Description     : This is a test expense 1
-Amount          : 13.37
-Category        : Category Alpha
-Remarks         :
-Currency        : SGD
-Mode of Payment :
 
 
 ERROR: The command entered is invalid.


### PR DESCRIPTION
- added rate to convert-currency command (optional field)
With currency API working: 
- If rate is provided, command will use provided rate
- If not, will use hashmap's rate
With currency API not working:
- Will use rate provided only
- If rate not provided, will throw exception